### PR TITLE
Check for uname and it's output for Darwin compilation

### DIFF
--- a/plugins.mk
+++ b/plugins.mk
@@ -8,3 +8,9 @@ CFLAGS += -I"$(THIS)/compat/"
 endif
 
 CFLAGS += -I"$(THIS)"
+ifneq (, $(shell which uname))
+  UNAME_A := $(shell uname -a)
+  ifneq ($(filter Darwin%, $(UNAME_A)),)
+    CFLAGS += -Wno-implicit-function-declaration
+  endif
+endif


### PR DESCRIPTION
Add proper -W flag to work around darwin compilation problem.

A better fix would be to have the relevant function (erl_drv_steal_main_thread) and necessary structures exposed in header files if they're really meant to be used.
